### PR TITLE
fix(readme): update osx package name

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ sudo gpasswd -a ${USER} docker
 
 On peut faire l'installation avec Homebrew
 ```
-brew cask install dockertoolbox
+brew cask install docker-toolbox
 ```
 
 ### Amélioration des performances sous OSX


### PR DESCRIPTION
Replace `dockertoolbox` with `docker-toolbox` into Max OS X section